### PR TITLE
Add support for ceiling lights command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "switchbot_api"
-version = "1.3.0"
+version = "1.4.0"
 description = "An asynchronous library to use Switchbot API"
 authors = ["Ravaka Razafimanantsoa <contact@ravaka.dev>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "switchbot_api"
-version = "1.4.0"
+version = "2.0"
 description = "An asynchronous library to use Switchbot API"
 authors = ["Ravaka Razafimanantsoa <contact@ravaka.dev>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "switchbot_api"
-version = "2.0"
+version = "2.0.0"
 description = "An asynchronous library to use Switchbot API"
 authors = ["Ravaka Razafimanantsoa <contact@ravaka.dev>"]
 license = "MIT"

--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -150,7 +150,7 @@ class CeilingLightCommands(Commands):
     """Ceiling light commands."""
 
     # 1-100
-    SET_BRIGHTNESS = "setBrightness" 
+    SET_BRIGHTNESS = "setBrightness"
     # 2700-6500
     SET_COLOR_TEMPERATURE = "setColorTemperature"
 
@@ -206,7 +206,7 @@ class SwitchBotAPI:
                 body = await response.json()
 
                 if response.status >= 400:
-                    raise CannotConnect() 
+                    raise CannotConnect()
                     
                 match body.get("statusCode"):
                     case 100:
@@ -217,7 +217,6 @@ class SwitchBotAPI:
                         _LOGGER.error("Error %s: %s", response.status, body)
                         raise CannotConnect()
                 
-
     async def list_devices(self):
         """List devices."""
         body = await self._request("devices")

--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -211,7 +211,11 @@ class SwitchBotAPI:
                 match body.get("statusCode"):
                     case 100:
                         return body.get("body")
-                    case 171:
+                    case 161 | 171:
+                        # SwitchBot docs claim that 161 is the code for device
+                        # being offline, and 171 for a _hub_ being offline.
+                        # In testing, the Plug Mini (JP) return 171 when not 
+                        # online too.
                         raise DeviceOffline()
                     case _:
                         _LOGGER.error("Error %s: %s", response.status, body)

--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -27,7 +27,7 @@ class InvalidAuth(Exception):
 
 class DeviceOffline(Exception):
     """Device currently offline."""
-    
+
 
 @dataclass
 class Device:
@@ -207,20 +207,20 @@ class SwitchBotAPI:
 
                 if response.status >= 400:
                     raise CannotConnect()
-                    
+
                 match body.get("statusCode"):
                     case 100:
                         return body.get("body")
                     case 161 | 171:
                         # SwitchBot docs claim that 161 is the code for device
                         # being offline, and 171 for a _hub_ being offline.
-                        # In testing, the Plug Mini (JP) return 171 when not 
+                        # In testing, the Plug Mini (JP) return 171 when not
                         # online too.
                         raise DeviceOffline()
                     case _:
                         _LOGGER.error("Error %s: %s", response.status, body)
                         raise CannotConnect()
-                
+
     async def list_devices(self):
         """List devices."""
         body = await self._request("devices")


### PR DESCRIPTION
Hey there! :)

First, I wanted to thank you for working on the SwitchBot Cloud Home Assistant integration — it made my life much easier :)

However, I have some devices I'm using that aren't supported by it (namely the Ceiling Light Pro), so I took a stab at implementing those integrations myself — and this is the API part of it.

I also added a `DeviceOffline`, to be able to handle situation where you try to toggle a switch that's fallen off the network a bit more cleanly from HASS side — currently it just throws a "unknown error occured" in the UI.

I'm still working on and need to clean up the HASS part itself, but if you're curious, you can take a peek here: https://github.com/home-assistant/core/compare/dev...jklausa:core:switchbot-cloud-ceiling-light

If you have any feedback/suggestions, I'm more than open to it — I haven't written Python in like... 10 years, so my instincts are more than a little bit rusty :)

