### PR TITLE
Add SwitchBot Bot press command

### DIFF
--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -172,6 +172,12 @@ class VacuumCommands(Commands):
     POW_LEVEL = "PowLevel"
 
 
+class BotCommands(Commands):
+    """Bot commands."""
+
+    PRESS = "press"
+
+
 T = TypeVar("T", bound=CommonCommands)
 
 


### PR DESCRIPTION
Adds the `press` command for the SwitchBot Bot, the `turnOn` and `turnOff` commands were already supported through `CommonCommands`.