### PR TITLE
Add mashumaro for typing of the devices

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -456,13 +456,13 @@ files = [
 
 [[package]]
 name = "identify"
-version = "2.6.5"
+version = "2.6.6"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "identify-2.6.5-py2.py3-none-any.whl", hash = "sha256:14181a47091eb75b337af4c23078c9d09225cd4c48929f521f3bf16b09d02566"},
-    {file = "identify-2.6.5.tar.gz", hash = "sha256:c10b33f250e5bba374fae86fb57f3adcebf1161bce7cdf92031915fd480c13bc"},
+    {file = "identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881"},
+    {file = "identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251"},
 ]
 
 [package.extras]
@@ -492,6 +492,26 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "mashumaro"
+version = "3.15"
+description = "Fast and well tested serialization library"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "mashumaro-3.15-py3-none-any.whl", hash = "sha256:cdd45ef5a4d09860846a3ee37a4c2f5f4bc70eb158caa55648c4c99451ca6c4c"},
+    {file = "mashumaro-3.15.tar.gz", hash = "sha256:32a2a38a1e942a07f2cbf9c3061cb2a247714ee53e36a5958548b66bd116d0a9"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+msgpack = ["msgpack (>=0.5.6)"]
+orjson = ["orjson"]
+toml = ["tomli (>=1.1.0)", "tomli-w (>=1.0)"]
+yaml = ["pyyaml (>=3.13)"]
 
 [[package]]
 name = "multidict"
@@ -733,13 +753,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "4.0.1"
+version = "4.1.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pre_commit-4.0.1-py2.py3-none-any.whl", hash = "sha256:efde913840816312445dc98787724647c65473daefe420785f885e8ed9a06878"},
-    {file = "pre_commit-4.0.1.tar.gz", hash = "sha256:80905ac375958c0444c65e9cebebd948b3cdb518f335a091a670a89d652139d2"},
+    {file = "pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b"},
+    {file = "pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4"},
 ]
 
 [package.dependencies]
@@ -1313,4 +1333,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "93ef926194c8644aac78c5ee192554921c161fc098bc007a915d7cc2c391c114"
+content-hash = "52432e4eb781f04e93cb0dd51a9f3365c811d6bb7dffbb00a70ad6b01ae55a49"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/SeraphicCorp/py-switchbot-api"
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = ">=3.0.0"
+mashumaro = "^3.15"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/switchbot_api/const.py
+++ b/switchbot_api/const.py
@@ -1,0 +1,11 @@
+"""Constants for SwitchBot API."""
+
+from enum import StrEnum
+
+
+class Model(StrEnum):
+    """Model of SwitchBot device."""
+
+    HUB_2 = "Hub 2"
+    CURTAIN = "Curtain"
+    CURTAIN3 = "Curtain3"

--- a/switchbot_api/models.py
+++ b/switchbot_api/models.py
@@ -1,0 +1,138 @@
+"""Models for SwitchBot API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Annotated, Any
+
+from mashumaro import field_options
+from mashumaro.mixins.json import DataClassJSONMixin
+from mashumaro.types import Discriminator
+
+from switchbot_api.const import Model
+
+
+class OpenDirection(StrEnum):
+    """Open direction."""
+
+    LEFT = "left"
+    RIGHT = "right"
+
+
+@dataclass
+class DeviceList(DataClassJSONMixin):
+    """Device list."""
+
+    devices: list[
+        Annotated[Device, Discriminator(field="deviceType", include_subtypes=True)]
+    ] = field(metadata=field_options(alias="deviceList"))
+    remotes: list[Remote] = field(metadata=field_options(alias="infraredRemoteList"))
+
+
+@dataclass
+class Device:
+    """Device."""
+
+    deviceType: Model  # noqa: N815
+    device_id: str = field(metadata=field_options(alias="deviceId"))
+    name: str = field(metadata=field_options(alias="deviceName"))
+    type: Model = field(metadata=field_options(alias="deviceType"))
+    hub_device_id: str | None = field(metadata=field_options(alias="hubDeviceId"))
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Pre deserialize hook."""
+        if d["hubDeviceId"] == "":
+            d["hubDeviceId"] = None
+        return d
+
+
+@dataclass
+class Hub2(Device):
+    """Hub2 device."""
+
+    deviceType = Model.HUB_2  # noqa: N815
+
+
+@dataclass
+class Curtain3(Device):
+    """Curtain3 device."""
+
+    deviceType = Model.CURTAIN3  # noqa: N815
+    calibrate: bool
+    open_direction: OpenDirection = field(metadata=field_options(alias="openDirection"))
+    main: bool = field(metadata=field_options(alias="master"))
+
+
+@dataclass
+class Curtain(Device):
+    """Curtain device."""
+
+    deviceType = Model.CURTAIN  # noqa: N815
+    calibrate: bool
+    group: bool
+    curtain_devices_ids: list[str] = field(
+        metadata=field_options(alias="curtainDevicesIds")
+    )
+
+
+@dataclass
+class Remote:
+    """Remote device."""
+
+    device_id: str = field(metadata=field_options(alias="deviceId"))
+    name: str = field(metadata=field_options(alias="deviceName"))
+    type: str = field(metadata=field_options(alias="remoteType"))
+    hub_device_id: str = field(metadata=field_options(alias="hubDeviceId"))
+
+
+@dataclass
+class DeviceStatus(DataClassJSONMixin):
+    """Device status."""
+
+    class Config:
+        """Config."""
+
+        discriminator = Discriminator(field="deviceType", include_subtypes=True)
+
+    deviceType: Model  # noqa: N815
+    version: str
+    device_id: str = field(metadata=field_options(alias="deviceId"))
+    type: Model = field(metadata=field_options(alias="deviceType"))
+    hub_device_id: str | None = field(metadata=field_options(alias="hubDeviceId"))
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Pre deserialize hook."""
+        if d["hubDeviceId"] in ["000000000000", d["deviceId"]]:
+            d["hubDeviceId"] = None
+        return d
+
+
+@dataclass
+class Hub2Status(DeviceStatus):
+    """Hub2 status."""
+
+    deviceType = Model.HUB_2  # noqa: N815
+    temperature: float
+    humidity: float
+
+
+@dataclass
+class CurtainStatus(DeviceStatus):
+    """Curtain status."""
+
+    deviceType = Model.CURTAIN  # noqa: N815
+    calibrate: bool
+    group: bool
+    moving: bool
+    battery: int
+    slide_position: int = field(metadata=field_options(alias="slidePosition"))
+
+
+@dataclass
+class Curtain3Status(CurtainStatus):
+    """Hub2 status."""
+
+    deviceType = Model.CURTAIN3  # noqa: N815

--- a/tests/__snapshots__/test_client.ambr
+++ b/tests/__snapshots__/test_client.ambr
@@ -1,48 +1,67 @@
 # serializer version: 1
 # name: test_device_list
-  list([
-    dict({
-      'device_id': 'D82812821F08',
-      'device_name': 'Hub 2 08',
-      'device_type': 'Hub 2',
-      'hub_device_id': '',
-    }),
-    dict({
-      'device_id': 'E2562C1DCC1A',
-      'device_name': 'Curtain 1A',
-      'device_type': 'Curtain3',
-      'hub_device_id': 'D82812821F08',
-    }),
-    dict({
-      'device_id': 'FCE84BB8B04F',
-      'device_name': 'Curtain 4F',
-      'device_type': 'Curtain',
-      'hub_device_id': '',
-    }),
-    dict({
-      'device_id': 'FF711F51601E',
-      'device_name': 'Curtain 1E',
-      'device_type': 'Curtain3',
-      'hub_device_id': 'D82812821F08',
-    }),
-    dict({
-      'device_id': '01-202501201703-63754985',
-      'device_name': 'TV',
-      'device_type': 'DIY TV',
-      'hub_device_id': 'D82812821F08',
-    }),
-  ])
+  dict({
+    'devices': list([
+      dict({
+        'deviceType': <Model.HUB_2: 'Hub 2'>,
+        'device_id': 'D82812821F08',
+        'hub_device_id': None,
+        'name': 'Hub 2 08',
+        'type': <Model.HUB_2: 'Hub 2'>,
+      }),
+      dict({
+        'calibrate': True,
+        'deviceType': <Model.CURTAIN3: 'Curtain3'>,
+        'device_id': 'E2562C1DCC1A',
+        'hub_device_id': 'D82812821F08',
+        'main': True,
+        'name': 'Curtain 1A',
+        'open_direction': <OpenDirection.LEFT: 'left'>,
+        'type': <Model.CURTAIN3: 'Curtain3'>,
+      }),
+      dict({
+        'calibrate': True,
+        'curtain_devices_ids': list([
+        ]),
+        'deviceType': <Model.CURTAIN: 'Curtain'>,
+        'device_id': 'FCE84BB8B04F',
+        'group': False,
+        'hub_device_id': None,
+        'name': 'Curtain 4F',
+        'type': <Model.CURTAIN: 'Curtain'>,
+      }),
+      dict({
+        'calibrate': True,
+        'deviceType': <Model.CURTAIN3: 'Curtain3'>,
+        'device_id': 'FF711F51601E',
+        'hub_device_id': 'D82812821F08',
+        'main': True,
+        'name': 'Curtain 1E',
+        'open_direction': <OpenDirection.LEFT: 'left'>,
+        'type': <Model.CURTAIN3: 'Curtain3'>,
+      }),
+    ]),
+    'remotes': list([
+      dict({
+        'device_id': '01-202501201703-63754985',
+        'hub_device_id': 'D82812821F08',
+        'name': 'TV',
+        'type': 'DIY TV',
+      }),
+    ]),
+  })
 # ---
 # name: test_device_status[curtain3]
   dict({
     'battery': 44,
     'calibrate': True,
-    'deviceId': 'FF711F51601E',
-    'deviceType': 'Curtain3',
+    'deviceType': <Model.CURTAIN3: 'Curtain3'>,
+    'device_id': 'FF711F51601E',
     'group': False,
-    'hubDeviceId': 'D82812821F08',
+    'hub_device_id': 'D82812821F08',
     'moving': False,
-    'slidePosition': 0,
+    'slide_position': 0,
+    'type': <Model.CURTAIN3: 'Curtain3'>,
     'version': 'V1.2',
   })
 # ---
@@ -50,23 +69,24 @@
   dict({
     'battery': 0,
     'calibrate': False,
-    'deviceId': 'FCE84BB8B04F',
-    'deviceType': 'Curtain',
+    'deviceType': <Model.CURTAIN: 'Curtain'>,
+    'device_id': 'FCE84BB8B04F',
     'group': False,
-    'hubDeviceId': '000000000000',
+    'hub_device_id': None,
     'moving': False,
-    'slidePosition': 0,
+    'slide_position': 0,
+    'type': <Model.CURTAIN: 'Curtain'>,
     'version': 'V6.3',
   })
 # ---
 # name: test_device_status[hub_2]
   dict({
-    'deviceId': 'D82812821F08',
-    'deviceType': 'Hub 2',
-    'hubDeviceId': 'D82812821F08',
-    'humidity': 52,
-    'lightLevel': 1,
+    'deviceType': <Model.HUB_2: 'Hub 2'>,
+    'device_id': 'D82812821F08',
+    'hub_device_id': None,
+    'humidity': 52.0,
     'temperature': 17.8,
+    'type': <Model.HUB_2: 'Hub 2'>,
     'version': 'V2.3-1.4',
   })
 # ---


### PR DESCRIPTION
Okay so this is an interesting one.

In this PR I am adding mashumaro to make sure we type all the device data we get. The big benefit is that this is typed, which means we can accidentally request data from a device it doesn't have. We become a bit more wary about what data we receive and what data we have, instead of just receiving it and passing it through.

The downside of this, is that we now need explicit support for every device we want to use. But the benefit that will have is that we will have more real life test data when adding a new device, so we ensure that the API still works as expected.

This extra abstraction layer helps us to iron out little details switchbot put in their API, like the `00000000` or the same deviceId as `hubDeviceId`.

I think before we can release this we need to make sure we collect all the devices we currently support. And I will work on a home Assistant proof of concept to show the full picture