### PR TITLE
Add suite for <Circulator Fan> of SwitchBotAPI

### DIFF
--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -142,7 +142,7 @@ class FanCommands(Commands):
     HIGH_SPEED = "highSpeed"
 
 
-class BatteryCirculatorFanCommandS(Commands):
+class BatteryCirculatorFanCommands(Commands):
     """Command types currently supported by SwitchBot Cloud [Battery Circulator Fan] API."""
 
     SET_WIND_SPEED = "setWindSpeed"

--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -10,7 +10,7 @@ import hmac
 import logging
 import socket
 import time
-from typing import Any, Self, TypeVar
+from typing import Any, Self, TypeVar, List
 import uuid
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
@@ -142,6 +142,14 @@ class FanCommands(Commands):
     HIGH_SPEED = "highSpeed"
 
 
+class BatteryCirculatorFanCommandS(Commands):
+    """Command types currently supported by SwitchBot Cloud [Battery Circulator Fan] API."""
+
+    SET_WIND_SPEED = "setWindSpeed"
+    SET_WIND_MODE = "setWindMode"
+    SET_NIGHT_LIGHT_MODE = "setNightLightMode"
+
+
 class LightCommands(Commands):
     """Light commands."""
 
@@ -178,6 +186,20 @@ class BotCommands(Commands):
     """Bot commands."""
 
     PRESS = "press"
+
+
+class BatteryCirculatorFanMode(Enum):
+    """Fan mode types currently supported by SwitchBot Cloud [Battery Circulator Fan] API."""
+
+    DIRECT = "direct"
+    NATURAL = "natural"
+    SLEEP = "sleep"
+    BABY = "baby"
+
+    @classmethod
+    def get_all_obj(cls) -> List[BatteryCirculatorFanMode]:
+        """Get all supported mode type as list."""
+        return [cls.DIRECT, cls.NATURAL, cls.SLEEP, cls.BABY]
 
 
 T = TypeVar("T", bound=CommonCommands)

--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -10,7 +10,7 @@ import hmac
 import logging
 import socket
 import time
-from typing import Any, Self, TypeVar, List
+from typing import Any, Self, TypeVar
 import uuid
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
@@ -143,7 +143,7 @@ class FanCommands(Commands):
 
 
 class BatteryCirculatorFanCommands(Commands):
-    """Command types currently supported by SwitchBot Cloud [Battery Circulator Fan] API."""
+    """Command types for [Battery Circulator Fan] API."""
 
     SET_WIND_SPEED = "setWindSpeed"
     SET_WIND_MODE = "setWindMode"
@@ -189,7 +189,7 @@ class BotCommands(Commands):
 
 
 class BatteryCirculatorFanMode(StrEnum):
-    """Fan mode types currently supported by SwitchBot Cloud [Battery Circulator Fan] API."""
+    """Fan mode types [Battery Circulator Fan] API."""
 
     DIRECT = "direct"
     NATURAL = "natural"

--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 import hashlib
 import hmac
 import logging
@@ -188,18 +188,13 @@ class BotCommands(Commands):
     PRESS = "press"
 
 
-class BatteryCirculatorFanMode(Enum):
+class BatteryCirculatorFanMode(StrEnum):
     """Fan mode types currently supported by SwitchBot Cloud [Battery Circulator Fan] API."""
 
     DIRECT = "direct"
     NATURAL = "natural"
     SLEEP = "sleep"
     BABY = "baby"
-
-    @classmethod
-    def get_all_obj(cls) -> List[BatteryCirculatorFanMode]:
-        """Get all supported mode type as list."""
-        return [cls.DIRECT, cls.NATURAL, cls.SLEEP, cls.BABY]
 
 
 T = TypeVar("T", bound=CommonCommands)


### PR DESCRIPTION
 1. add Fan mode types currently supported by SwitchBot Cloud [Battery Circulator Fan] API 
 3. add Command types currently supported by SwitchBot Cloud [Battery Circulator Fan] API.