### PR TITLE
move pycryptodome to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/SeraphicCorp/py-switchbot-api"
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = ">=3.0.0"
-
+pycryptodome = ">=3.23.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = {version = "7.6.10", extras = ["toml"]}
@@ -28,7 +28,6 @@ codespell = "^2.3.0"
 pre-commit = "^4.0.1"
 pre-commit-hooks = "^5.0.0"
 yamllint = "^1.35.1"
-pycryptodome = "^3.23.0"
 
 [tool.mypy]
 # Specify the target platform details in config, so your developers are


### PR DESCRIPTION
Otherwise `import switchbot_api` fails with
    
    ModuleNotFoundError: No module named 'Crypto'