### PR TITLE
Fix KeyError 'deviceType' in get_status for IR remote devices

### DIFF
--- a/switchbot_api/__init__.py
+++ b/switchbot_api/__init__.py
@@ -262,7 +262,7 @@ class SwitchBotAPI:
         """No status for IR devices."""
         response = await self._request(METH_GET, f"devices/{device_id}/status")
 
-        device_type = response["deviceType"]
+        device_type = response.get("deviceType")
         if device_type and device_type in KeyPadCommands.get_supported_devices():
             return await self.get_device(device_id)
         return response

--- a/tests/fixtures/ir_remote.json
+++ b/tests/fixtures/ir_remote.json
@@ -1,0 +1,5 @@
+{
+  "statusCode": 100,
+  "body": {},
+  "message": "success"
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,3 +104,22 @@ async def test_device_status(
         body=load_fixture(f"{device_fixture}.json"),
     )
     assert await client.get_status("abc") == snapshot
+
+
+async def test_device_status_ir_remote(
+    client: SwitchBotAPI,
+    responses: aioresponses,
+) -> None:
+    """Test that fetching status for an IR remote does not raise.
+
+    The SwitchBot Cloud API returns an empty body for IR remote devices
+    (the docstring on ``get_status`` already notes "No status for IR
+    devices"), so the unwrapped response has no ``deviceType`` key.
+    Regression test: previously this raised ``KeyError: 'deviceType'``.
+    """
+    responses.get(
+        f"{MOCK_URL}/devices/abc/status",
+        status=200,
+        body=load_fixture("ir_remote.json"),
+    )
+    assert await client.get_status("abc") == {}


### PR DESCRIPTION
## Summary

Since #42 (released as 2.11.0) `SwitchBotAPI.get_status` does an unconditional `response["deviceType"]` lookup to detect Keypad devices. The SwitchBot Cloud API returns an empty body for IR remote devices — the docstring on `get_status` itself even notes *"No status for IR devices"* — so the unwrapped response dict has no `deviceType` key, and every coordinator backing an IR remote (and any other device whose status response omits `deviceType`) now raises `KeyError: 'deviceType'`.

In Home Assistant 2026.4.x (which bumped this library to 2.11.0 in home-assistant/core#164663) this surfaces as the `switchbot_cloud` integration repeatedly failing setup with the following traceback:

```
Unexpected error fetching switchbot_cloud data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 426, in _async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/components/switchbot_cloud/coordinator.py", line 70, in _async_update_data
    status: Status = await self._api.get_status(self._device_id)
  File "/usr/local/lib/python3.14/site-packages/switchbot_api/__init__.py", line 265, in get_status
    device_type = response["deviceType"]
                  ~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'deviceType'
```

## Fix

Use `dict.get` so the missing-key case falls through to the existing "return response as-is" path. This restores the pre-#42 behavior for IR remotes while preserving the keypad special-casing introduced in #42:

```diff
- device_type = response["deviceType"]
+ device_type = response.get("deviceType")
```

`if device_type and device_type in KeyPadCommands.get_supported_devices():` short-circuits cleanly when `device_type is None`, so no further changes are needed.

## Test plan

- [x] Added `tests/fixtures/ir_remote.json` modeling the empty-body response the SwitchBot Cloud API returns for IR remotes (`{"statusCode": 100, "body": {}, "message": "success"}`)
- [x] Added `test_device_status_ir_remote` regression test asserting `get_status` returns `{}` instead of raising
- [x] Verified the new test **fails on `main`** with the exact `KeyError: 'deviceType'` from the bug report, and **passes** with this fix applied
- [x] Full suite green: `pytest tests/` → 8 passed, 100% coverage, 4 snapshots passed
- [x] `ruff format --check` clean on touched files

## Refs

- Regression introduced in #42 (released in 2.11.0)
- Reported via Home Assistant `switchbot_cloud` setup failures after upgrading to HA Core 2026.4.x (home-assistant/core#164663)