### PR TITLE
Add support for Permanent Outdoor Lights to RGBWWLightCommands

### DIFF
--- a/switchbot_api/commands.py
+++ b/switchbot_api/commands.py
@@ -240,6 +240,7 @@ class RGBWWLightCommands(Commands):
             "Color Bulb",
             "RGBICWW Floor Lamp",
             "RGBICWW Strip Light",
+            "Permanent Outdoor Lights",
         ]
 
 


### PR DESCRIPTION
Add "Permanent Outdoor Lights" to RGBWWLightCommands.supported_devices so cloud control (color/white/scene) reaches the device.