### PR TITLE
Add Battery Circulator Fan 2 Pro to circulator fan commands

### DIFF
--- a/switchbot_api/commands.py
+++ b/switchbot_api/commands.py
@@ -374,7 +374,11 @@ class BatteryCirculatorFanCommands(Commands):
     @classmethod
     def get_supported_devices(cls) -> list[str]:
         """Get supported devices."""
-        return ["Circulator Fan", "Battery Circulator Fan"]
+        return [
+            "Circulator Fan",
+            "Battery Circulator Fan",
+            "Battery Circulator Fan 2 Pro",
+        ]
 
 
 class TVCommands(Commands):


### PR DESCRIPTION
## Summary

The SwitchBot **Circulator Fan Pro (W1160)** reports its cloud `deviceType` as **`Battery Circulator Fan 2 Pro`**. This adds it to the devices supported by `BatteryCirculatorFanCommands`, so its fan (mode / wind speed / on-off) and night light (`setNightLightMode`) can be controlled through the cloud API.

Verified against the real device via the SwitchBot cloud API (`getDeviceStatus` returns `deviceType: "Battery Circulator Fan 2 Pro"`; `setWindMode` / `setWindSpeed` / `setNightLightMode` confirmed working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)